### PR TITLE
Great utility! Minor tweak to output

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1,107 +1,124 @@
 import os
 import glob
-import filecmp
 import json
 from shutil import copy2
-whitelist = open('whitelist.txt').read()
-fileIndex = {}
-whitelist = whitelist.split("\n")
+from filecmp import cmp as compare
+from argparse import ArgumentParser
+from make_mod_patch import mod_patch
 
-# Set to true if updating a mod
-override = False
-while True:
-    print("Auto-override unmarked files? (True/False) or (t/f) or (yes/no) or (y/n)")
-    readin = input().lower()
-    if readin in ['true', 'false', 't', 'f', 'yes', 'y', 'no', 'n']:
-        if readin in ['true', 't', 'yes' 'y']:
-            override = True
-        break
-for item in whitelist:
-    entry = ''.join(e for e in item if e.isalnum())
-    if entry == "":
-        continue # Skip blank lines
-    fileList = glob.glob('mod/'+entry.replace("\n","")+'/**',recursive=True)
-    for filename in fileList:
-        # Hack together the destination path
-        file_path = str(filename).split(os.sep)
-        file_path[0] = "mod/! Modpack"
-        name = str(filename)
-        filePath = os.sep.join(file_path)
-        path_within_mod = os.sep.join(file_path[1:])
-        # If this file exists in our modpack and has different contents, move it to the conflicts folder
-        if os.path.isfile(filePath) and os.path.isfile(name) and not filecmp.cmp(filePath, name):
-            # Check if file has been manually modified
-            f = open(filePath,"r")
-            try:
-                lines = f.readlines()
-                modification = lines[0]
-                f.close()
-                # Mark manually modified file with '#MODIFIED' as the first line, files not marked will be auto overriden
-                if override:
-                    if "#MODIFIED" in modification:
-                        fname, extension = file_path[-1].split('.')
-                        file_path[-1] = fname + " " + entry.strip() + "." +  extension
-                        file_path[0] = "mod/!conflicts!"
-                        print_conflict_path = os.sep.join(file_path[1:])
-                        print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
-                    else:
-                        print("Overriding " + os.sep.join(file_path))
-                        os.remove(os.sep.join(file_path))
-                else:
-                    if "#MODIFIED" not in modification:
-                        with open(filePath, "w") as dest:
-                            dest.write("#MODIFIED\n")
-                            dest.write("".join(lines))
-                    fname, extension = file_path[-1].split('.')
-                    file_path[-1] = fname + " " + entry.strip() + "." +  extension
-                    file_path[0] = "mod/!conflicts!"
-                    print_conflict_path = os.sep.join(file_path[1:])
-                    print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
-            except Exception as e:
+
+def make_modpack(modpack_name, overwrite):
+    print("\nAssembling modpack...")
+    fileIndex = dict()
+    whitelist = open('whitelist.txt').read().split('\n')
+    # Keep only the alphanumeric characters in the names in the whitelist, remove blank lines:
+    whitelist = [''.join(char for char in list_entry if char.isalnum()) for list_entry in whitelist if list_entry]
+
+    patch_created = False
+    if os.path.isdir(f"mod{os.sep}{modpack_name}") and not overwrite:
+        print(f"The {modpack_name} directory already exists...")
+        patch_name = ''.join(char for char in modpack_name if char.isalnum()) + "Patch"
+        if os.path.isdir(f"mod{os.sep}{patch_name}"):
+            print("It looks like a modpack patch has already been created for this modpack. Checking for new changes.")
+            new_changes_present = mod_patch(modpack_name, check_only=True)
+            if new_changes_present:
+                print(f"\nIt looks like there are additional changes in your {modpack_name} folder aside from those saved in {patch_name}.")
+                print(f"This process will abort in order to prevent loss of changes in your {modpack_name} or overwriting of files in your {patch_name} folder.")
+                print(f"To force skip the patch creation process and overwrite files in the {modpack_name} folder, run \"installer.py -ovr\"")
+                print(f"To force the updating of the contents of {patch_name}, run \"make_mod_patch.py\" and then run \"installer.py\" again.")
+                print("If the only differing files are in the modpack patch itself, you must run \"installer.py -ovr\" to push those files into the modpack.")
+                return
+            else:
+                print("There are no additional changes in the modpack aside from those already in the patch.")
+        else:
+            patch_created = mod_patch(modpack_name, add_to_whitelist=False)
+        print("Continuing to assemble modpack...\n")
+
+    for entry in whitelist:
+        fileList = glob.glob(f'mod{os.sep}{entry}{os.sep}**', recursive=True)
+        for cur_file in fileList:
+            if not os.path.isfile(cur_file) or ".mod" in cur_file:
+                continue  # Skip directory the folders themselves and mod descriptor files.
+            file_path = cur_file.split(os.sep)
+            file_path[1] = modpack_name  # Change folder to the modpack.
+            path_within_mod = os.sep.join(file_path[2:])
+            if path_within_mod in fileIndex:
+                # There is already a file at this path in the modpack, it is either a conflict or a duplicate.
+                if compare(cur_file, os.sep.join(file_path)):
+                    fileIndex[path_within_mod][0].append(f"DUPLICATE: {entry.strip()}")
+                    fileIndex[path_within_mod][2] += 1
+                    continue  # Skip duplicate files.
+                # File is a conflict:
+                fileIndex[path_within_mod][0].append(f"CONFLICT: {entry.strip()}")
+                fileIndex[path_within_mod][1] += 1
+                file_path[1] = f"{modpack_name}_conflicts!"  # Copy the conflicting file to the conflicts folder.
                 fname, extension = file_path[-1].split('.')
                 file_path[-1] = fname + " " + entry.strip() + "." +  extension
-                file_path[0] = "mod/!conflicts!"
-                print_conflict_path = os.sep.join(file_path[1:])
-                print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
-
-        # Finalize our destination path
-        filePath = os.sep.join(file_path)
-        path = os.path.dirname(filePath)
-        if not os.path.exists(path):
-            os.makedirs(path)
-        # Do not copy descriptor.mod, makes file explorer crash-y for some reason.
-        if os.path.isfile(name) and ".mod" not in name:
-            if path_within_mod in fileIndex:
-                fileIndex[path_within_mod][0].append(entry.strip())
-                fileIndex[path_within_mod][1] += 1
+                print(f"Confict detected. Moving to {os.sep.join(file_path[1:])}.")
             else:
-                fileIndex[path_within_mod] = [[entry.strip()], 0]
-            copy2(name, filePath)
+                # First time we've seen a file at this path.
+                # First entry in the dict is for mod source, second is for conflict count, third is for repeat count.
+                fileIndex[path_within_mod] = [[(f"SELECTED: {entry.strip()}")], 0, 0]
+            # Make dirs if necessary:
+            target_path = os.sep.join(file_path)
+            target_dir = os.path.dirname(target_path)
+            if not os.path.exists(target_dir):
+                os.makedirs(target_dir)
+            # Copy the mod file to its destination.
+            copy2(cur_file, target_path)
 
-try:
-    conflicts_list = dict()
-    for i in fileIndex:
-        if fileIndex[i][1]:
-            conflicts_list[i] = fileIndex[i][0]
-        fileIndex[i] = fileIndex[i][0]
+    print("\n\nDone copying files.")
+    if fileIndex:
+        with open(f'mod{os.sep}{modpack_name}{os.sep}whitelist.txt', "w+") as f:
+            f.writelines([i +'\n' for i in whitelist])
 
-    # Output a list of all files and a list of the conflicting files
-    fileIndexOut = open("mod/!conflicts!/allFilesList.txt","w+")
-    fileIndexOut.write(json.dumps(fileIndex, indent = 4))
-    fileIndexOut.close()
-    conflictsOut = open("mod/!conflicts!/conflictingFilesList.txt","w+")
-    conflictsOut.write(json.dumps(conflicts_list, indent = 4))
-    conflictsOut.close()
-    print("Conflicting files listed in mod/!conflicts!/conflictingFilesList.txt")
-except:
-    print("No conflicts!")
+        conflicts_dict = dict()
+        duplicates_dict = dict()
+        for i in fileIndex:
+            if fileIndex[i][1]:
+                conflicts_dict[i] = fileIndex[i][0]
+            if fileIndex[i][2]:
+                duplicates_dict[i] = fileIndex[i][0]
+            fileIndex[i] = fileIndex[i][0]
 
-if not os.path.isfile("mod/Modpack.mod"):
-    descriptor = open("mod/Modpack.mod","w+")
-    descriptor.write("""name=\"! Modpack"
-path=\"mod/! Modpack\"
-tags={
-	\"Gameplay\"
-}
-supported_version=\"2.7.*\"""")
-print("Done!")
+        # Output a list of all files.
+        with open(f"mod{os.sep}{modpack_name}{os.sep}allFilesList.txt", "w+") as f:
+            f.write(json.dumps(fileIndex, indent = 4))
+        if duplicates_dict:
+            # Output a list of duplicate files.
+            with open(f"mod{os.sep}{modpack_name}{os.sep}duplicateFilesList.txt", "w+") as f:
+                f.write(json.dumps(duplicates_dict, indent = 4))
+            print(f"Duplicate files listed in mod{os.sep}{modpack_name}{os.sep}duplicateFilesList.txt")
+        if conflicts_dict:
+            # Output a list of conflicting files.
+            with open(f"mod{os.sep}{modpack_name}_conflicts!{os.sep}conflictingFilesList.txt", "w+") as f:
+                f.write(json.dumps(conflicts_dict, indent = 4))
+            print(f"Conflicting files listed in mod{os.sep}{modpack_name}_conflicts!{os.sep}conflictingFilesList.txt")
+        else:
+            print("No conflicts!")
+
+    mod_descriptor_name = ''.join(char for char in modpack_name if char.isalnum()).capitalize()
+    if not os.path.isfile(f"mod{os.sep}{mod_descriptor_name}.mod"):
+        with open(f"mod{os.sep}{mod_descriptor_name}.mod", "w+") as f:
+            f.writelines([f"name=\"{modpack_name}\"\n", f"path=\"mod/{modpack_name}\"\n", "tags={\n", "\t\"Gameplay\"\n", "}\n", "supported_version=\"2.7.*\"\n"])
+
+    if patch_created:
+        print("A modpack patch was created in order to preserve the customizations in the modpack folder.")
+        print(f"To revert the customizations to your modpack, add {patch_name} to your whitelist (at the top if you want to ensure your customizations are prioritized).")
+    print("Done!")
+
+
+def get_name_from_cl():
+    parser = ArgumentParser()
+    parser.add_argument('-n', '--modpack_name', default="! modpack", type=str,
+        help='The name of the modpack (both the folder name and the name in the stellaris launcher).')
+    parser.add_argument('-ovr', '--nopatch', action='store_true', default=False,
+        help="Add this argument to overwrite files in the mod folder without generating a patch. By default, " \
+            "modifications within the *modpack_name* folder will be saved to a new mod called *modpack_name*_patch")
+    args = parser.parse_args()
+    return args.modpack_name, args.nopatch
+
+
+if __name__ == "__main__":
+    modpack_name, overwrite = get_name_from_cl()
+    make_modpack(modpack_name, overwrite)

--- a/make_mod_patch.py
+++ b/make_mod_patch.py
@@ -1,0 +1,137 @@
+# This utility examines all the files in the ! Modpack folder (or in the folder specified by the -mod command line argument).
+# The files are compared to the files in the extracted mod folders that would be put into the modpack folder according to the whitelist.txt file.
+# Any files in the modpack folder that differ from the expected file are copied into the mod\ModpackPatch folder.
+
+# What is the point of all this?
+
+# After merging mods into a modpack, a user may want to replace one of the conflicting files with a file from a different mod,
+# or perhaps even make manual modifications to the files in the modpack.
+# Running this script to create a modpack patch is a way to sort of "save" the changes made to a modpack.
+
+# The various mods in the modpack can then be updated via the standard workflow when new releases of any of the mods come out,
+# after which a user can compare changed files in the mod with their custom changes in the patch through whatever diff method the user prefers.
+
+# The modpackPatch is not intended to be added to your active mods in the stellaris launcher (it will add nothing the modpack doesn't already add)
+# it's just a tool to help customize modpacks, save modified files, and save the way you've resolved conflicts,
+# and then easily re-impliment or diff the changes you've made when new versions of the mods come out or when you add new mods to the modpack.
+
+import os
+import glob
+
+from shutil import copy2
+from filecmp import cmp as compare
+from argparse import ArgumentParser
+
+
+def mod_patch(modpack_name, add_to_whitelist=True, check_only=False):
+    changes_present = False
+    changeSet = set()
+    patch_name = ''.join(char for char in modpack_name if char.isalnum()) + "Patch"
+    print(f"\nChecking for customizations in {modpack_name}...\n")
+    fileSet = {"duplicateFilesList.txt", "allFilesList.txt", "whitelist.txt"}  # To avoid copying these meta lists to the patch folder.
+    patch_created = False
+    whitelist = open(f'mod{os.sep}{modpack_name}{os.sep}whitelist.txt').read().split("\n")
+    # Keep only the alphanumeric characters in the names in the whitelist, remove blank lines:
+    whitelist = [''.join(char for char in list_entry if char.isalnum()) for list_entry in whitelist if list_entry]
+    for entry in whitelist:
+        fileList = glob.glob(f'mod{os.sep}{entry}{os.sep}**', recursive=True)
+        for cur_file in fileList:
+            if not os.path.isfile(cur_file) or ".mod" in cur_file:
+                continue  # Skip directory the folders themselves and mod descriptor files.
+            file_path = cur_file.split(os.sep)
+            file_path[1] = modpack_name  # Change folder to the modpack.
+            path_within_mod = os.sep.join(file_path[2:])
+            if path_within_mod in fileSet:
+                # A file with this path has already been compared.
+                # The cur_file might be a conflict or maybe a duplicate.
+                # Either way, no checking is necessary, so go to the next file.
+                continue
+            if compare(cur_file, os.sep.join(file_path)):
+                # The first mod on the whitelist that has this file has an identical file to the file in the modpack.
+                # This means no customization has been made, and nothing need be done.
+                fileSet.add(path_within_mod)
+            else:
+                # This file has been altered.
+                if check_only:
+                    changes_present = True
+                    if path_within_mod not in changeSet:
+                        print(f"File in modpack differs from file in mod: {os.sep.join(cur_file.split(os.sep)[1:])}")
+                    changeSet.add(path_within_mod)
+                    continue  # Advance to next file without any copying.
+                # Copy the file to the patch folder.
+                print(f"Adding customized file to patch: {path_within_mod}")
+                patch_created = True
+                fileSet.add(path_within_mod)
+                modified_file = os.sep.join(file_path)
+                file_path[1] = patch_name  # Change folder to the patch.
+                target_path = os.sep.join(file_path)
+                target_dir = os.path.dirname(target_path)
+                if not os.path.exists(target_dir):
+                    os.makedirs(target_dir)
+                copy2(modified_file, target_path)
+
+    # Check the modpack for unique files that are not present in any of the mods on the whitelist.
+    all_mod_files = glob.glob(f'mod{os.sep}{modpack_name}{os.sep}**', recursive=True)
+    for cur_file in all_mod_files:
+        if not os.path.isfile(cur_file) or ".mod" in cur_file:
+            continue  # Skip directory the folders themselves and mod descriptor files.
+        file_path = cur_file.split(os.sep)
+        path_within_mod = os.sep.join(file_path[2:])
+        if path_within_mod not in fileSet:
+            # Even after looking through all of the mods, we've never seen this file. It must be new.
+            if check_only:
+                changes_present = True
+                if path_within_mod not in changeSet:
+                    print(f"File has been added to modpack: {path_within_mod}")
+                changeSet.add(path_within_mod)
+                continue  # Advance to next file without any copying.
+            # Copy the new file to the patch.
+            print(f"Adding unique file to patch: {path_within_mod}")
+            patch_created = True
+            file_path = cur_file.split(os.sep)
+            file_path[1] = patch_name
+            target_path = os.sep.join(file_path)
+            target_dir = os.path.dirname(target_path)
+            if not os.path.exists(target_dir):
+                 os.makedirs(target_dir)
+            copy2(cur_file, target_path)
+
+    if check_only:
+        if changes_present:
+            return True
+        return False  # Done checking for new changes - there were none!
+
+    if add_to_whitelist:
+        if patch_name not in whitelist:
+            whitelist.insert(0, patch_name)
+            with open(f"mod{os.sep}{modpack_name}{os.sep}whitelist.txt", "w+") as f:
+                f.writelines([i +'\n' for i in whitelist])
+        whitelist = open(f'whitelist.txt').read().split("\n")
+        if patch_name not in whitelist:
+            whitelist.insert(0, patch_name)
+            with open("whitelist.txt", "w+") as f:
+                f.writelines([i +'\n' for i in whitelist])
+
+    if patch_created:
+        if not os.path.isfile(f"mod{os.sep}{patch_name}.mod"):
+            with open(f"mod{os.sep}{patch_name}.mod", "w+") as f:
+                f.writelines([f"name=\"{patch_name}\"\n", f"path=\"mod{os.sep}{patch_name}\"\n", "tags={\n", "\t\"Gameplay\"\n", "}\n", "supported_version=\"2.7.*\"\n"])
+        print(f"\n\nCustomized files in \"{modpack_name}\" have been copied to \"{patch_name}\".{' The patch has been added to your whitelist.' if add_to_whitelist else ''}\n")
+    else:
+        print(f"\n\nNo customized files found in \"{modpack_name}\". No patch created.\n")
+
+    # Return a bool indicating that a patch has indeed been created.
+    return patch_created
+
+
+def get_name_from_cl():
+    parser = ArgumentParser()
+    parser.add_argument('-n', '--modpack_name', default="! modpack", type=str,
+        help='The name of the modpack (both the folder name and the name in the stellaris launcher).')
+    args = parser.parse_args()
+    return args.modpack_name
+
+
+if __name__ == "__main__":
+    modpack_name = get_name_from_cl()
+    mod_patch(modpack_name)

--- a/old_installer.py
+++ b/old_installer.py
@@ -1,0 +1,107 @@
+import os
+import glob
+import filecmp
+import json
+from shutil import copy2
+whitelist = open('whitelist.txt').read()
+fileIndex = {}
+whitelist = whitelist.split("\n")
+
+# Set to true if updating a mod
+override = False
+while True:
+    print("Auto-override unmarked files? (True/False) or (t/f) or (yes/no) or (y/n)")
+    readin = input().lower()
+    if readin in ['true', 'false', 't', 'f', 'yes', 'y', 'no', 'n']:
+        if readin in ['true', 't', 'yes' 'y']:
+            override = True
+        break
+for item in whitelist:
+    entry = ''.join(e for e in item if e.isalnum())
+    if entry == "":
+        continue # Skip blank lines
+    fileList = glob.glob('mod/'+entry.replace("\n","")+'/**',recursive=True)
+    for filename in fileList:
+        # Hack together the destination path
+        file_path = str(filename).split(os.sep)
+        file_path[0] = "mod/! Modpack"
+        name = str(filename)
+        filePath = os.sep.join(file_path)
+        path_within_mod = os.sep.join(file_path[1:])
+        # If this file exists in our modpack and has different contents, move it to the conflicts folder
+        if os.path.isfile(filePath) and os.path.isfile(name) and not filecmp.cmp(filePath, name):
+            # Check if file has been manually modified
+            f = open(filePath,"r")
+            try:
+                lines = f.readlines()
+                modification = lines[0]
+                f.close()
+                # Mark manually modified file with '#MODIFIED' as the first line, files not marked will be auto overriden
+                if override:
+                    if "#MODIFIED" in modification:
+                        fname, extension = file_path[-1].split('.')
+                        file_path[-1] = fname + " " + entry.strip() + "." +  extension
+                        file_path[0] = "mod/!conflicts!"
+                        print_conflict_path = os.sep.join(file_path[1:])
+                        print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
+                    else:
+                        print("Overriding " + os.sep.join(file_path))
+                        os.remove(os.sep.join(file_path))
+                else:
+                    if "#MODIFIED" not in modification:
+                        with open(filePath, "w") as dest:
+                            dest.write("#MODIFIED\n")
+                            dest.write("".join(lines))
+                    fname, extension = file_path[-1].split('.')
+                    file_path[-1] = fname + " " + entry.strip() + "." +  extension
+                    file_path[0] = "mod/!conflicts!"
+                    print_conflict_path = os.sep.join(file_path[1:])
+                    print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
+            except Exception as e:
+                fname, extension = file_path[-1].split('.')
+                file_path[-1] = fname + " " + entry.strip() + "." +  extension
+                file_path[0] = "mod/!conflicts!"
+                print_conflict_path = os.sep.join(file_path[1:])
+                print(f"Confict detected. Moving to !conficts!{os.sep}{print_conflict_path}.")
+
+        # Finalize our destination path
+        filePath = os.sep.join(file_path)
+        path = os.path.dirname(filePath)
+        if not os.path.exists(path):
+            os.makedirs(path)
+        # Do not copy descriptor.mod, makes file explorer crash-y for some reason.
+        if os.path.isfile(name) and ".mod" not in name:
+            if path_within_mod in fileIndex:
+                fileIndex[path_within_mod][0].append(entry.strip())
+                fileIndex[path_within_mod][1] += 1
+            else:
+                fileIndex[path_within_mod] = [[entry.strip()], 0]
+            copy2(name, filePath)
+
+try:
+    conflicts_list = dict()
+    for i in fileIndex:
+        if fileIndex[i][1]:
+            conflicts_list[i] = fileIndex[i][0]
+        fileIndex[i] = fileIndex[i][0]
+
+    # Output a list of all files and a list of the conflicting files
+    fileIndexOut = open("mod/!conflicts!/allFilesList.txt","w+")
+    fileIndexOut.write(json.dumps(fileIndex, indent = 4))
+    fileIndexOut.close()
+    conflictsOut = open("mod/!conflicts!/conflictingFilesList.txt","w+")
+    conflictsOut.write(json.dumps(conflicts_list, indent = 4))
+    conflictsOut.close()
+    print("Conflicting files listed in mod/!conflicts!/conflictingFilesList.txt")
+except:
+    print("No conflicts!")
+
+if not os.path.isfile("mod/Modpack.mod"):
+    descriptor = open("mod/Modpack.mod","w+")
+    descriptor.write("""name=\"! Modpack"
+path=\"mod/! Modpack\"
+tags={
+	\"Gameplay\"
+}
+supported_version=\"2.7.*\"""")
+print("Done!")


### PR DESCRIPTION
Hey mate,

This utility that you've created is really great! Thanks so much for making it. It's really helped my friends get together and play the game how we want with much less hassle.

I noticed that the list of files output to !conflicts!/filesList.txt was actually a list of every file in the modpack, rather than just the conflicting files. I've made a modification to add a list of just the conflicting files (and their sources).

Complete changes:
- installer.py is now Linux compatible.
- Conflicts are now output to the console.
- When files are moved to the !conflicts! folder, the file extension is preserved, rather than being set to .txt.
- ALL conflicting files are put in the !conflicts! folder, including '.gfx', '.asset', '.yml' and '.dds' files. I like to have easy access to these files as well, for compiling graphics and UI mod packs.
- List of conflicting files is now output to !conflicts!/conflictingFilesList.txt.

If these changes don't align with your goal for the utility, feel free to reject, or to just pick and choose from the changes I'm proposing.

Cheers,
Sam